### PR TITLE
fix: correct platform tag in Docker build workflow

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           context: .
           file: Dockerfile 
-          platforms: linux/amd6
+          platforms: linux/amd64
           push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
fix: correct platform tag in Docker build workflow