### PR TITLE
fix(S3): Correct MD5 decoding for S3 etag verification

### DIFF
--- a/S3.py
+++ b/S3.py
@@ -1868,7 +1868,7 @@ class S3(object):
 
         debug("MD5 sums: computed=%s, received=%s" % (md5_computed, md5_from_s3))
         try:
-            md5_from_s3_digest = md5_from_s3.decode('hex')
+            md5_from_s3_digest = md5_from_s3.encode('utf-8').decode('hex')
         except TypeError:
             md5_from_s3_digest = None
         ## when using KMS encryption, MD5 etag value will not match


### PR DESCRIPTION
This pull request includes a small change to the `send_file` method in the `S3.py` file. The change ensures that the `md5_from_s3` value is correctly encoded before decoding.

* [`S3.py`](diffhunk://#diff-987e28e74129c93b18bb38ae16b3a814ec2ed3c79b70181e2e98b6e98f0d2e8dL1871-R1871): Modified the `send_file` method to encode `md5_from_s3` in UTF-8 before decoding it from hex to handle potential encoding issues.